### PR TITLE
Add a make target, point to upjet fork

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,11 @@ run: go.build
 	@# To see other arguments that can be provided, run the command with --help instead
 	UPBOUND_CONTEXT="local" $(GO_OUT_DIR)/provider --debug
 
+debug: go.build
+	@$(INFO) Running Crossplane locally out-of-cluster in debug mode . . .
+	@# To see other arguments that can be provided, run the command with --help instead
+	UPBOUND_CONTEXT="local" dlv exec $(GO_OUT_DIR)/provider -- --debug
+
 # NOTE(hasheddan): we ensure up is installed prior to running platform-specific
 # build steps in parallel to avoid encountering an installation race condition.
 build.init: $(UP)

--- a/go.mod
+++ b/go.mod
@@ -156,3 +156,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace github.com/crossplane/upjet => github.com/tchinmai7/upjet v0.0.0-20240725221335-67bd255fdb28

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,6 @@ github.com/crossplane/crossplane-runtime v1.16.0 h1:lz+l0wEB3qowdTmN7t0PZkfuNSvf
 github.com/crossplane/crossplane-runtime v1.16.0/go.mod h1:Pz2tdGVMF6KDGzHZOkvKro0nKc8EzK0sb/nSA7pH4Dc=
 github.com/crossplane/crossplane-tools v0.0.0-20240516011917-bfb5045f0903 h1:bL8QbWkmzkdK7swURaaKEFiYS8+ib4fYU74eyRpCrYg=
 github.com/crossplane/crossplane-tools v0.0.0-20240516011917-bfb5045f0903/go.mod h1:cN0Y7PFGQMM8mcagXVCbeQoKtipmFWQTPZYyziCPBUI=
-github.com/crossplane/upjet v1.4.0 h1:twKCU8omU7VAA7E5fpbQkqDHjVnoTb8EXqmB805Q37o=
-github.com/crossplane/upjet v1.4.0/go.mod h1:3pDVtCgyBc5f2Zx4K5HEPxxhjndmOc5CHCJNpIivK/g=
 github.com/dave/jennifer v1.7.0 h1:uRbSBH9UTS64yXbh4FrMHfgfY762RD+C7bUPKODpSJE=
 github.com/dave/jennifer v1.7.0/go.mod h1:nXbxhEmQfOZhWml3D1cDK5M1FLnMSozpbFN/m3RmGZc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -312,6 +310,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/tchinmai7/upjet v0.0.0-20240725221335-67bd255fdb28 h1:BM/ZcFrf0mZVDtfZHv1dPTu2AO4H10xYaX42Fkx62YY=
+github.com/tchinmai7/upjet v0.0.0-20240725221335-67bd255fdb28/go.mod h1:wkdZf/Cvhr6PI30VdHIOjg4dX39Z5uijqnLWFk5PbGM=
 github.com/tmccombs/hcl2json v0.3.3 h1:+DLNYqpWE0CsOQiEZu+OZm5ZBImake3wtITYxQ8uLFQ=
 github.com/tmccombs/hcl2json v0.3.3/go.mod h1:Y2chtz2x9bAeRTvSibVRVgbLJhLJXKlUeIvjeVdnm4w=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
- Add make target to debug the executable in dlv
- Point to upjet fork that contains fix for nil pointer exception when creating keys
Reference: https://github.com/crossplane/upjet/commit/67bd255fdb286b483c9ef750209cec4eff87e523 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
- Run `make local-deploy` and `make debug`
- Prior to the upjet change, creating a key using the generated key example resulted in an error like:
```
Reconciler error        {"controller": "managed/objectstorage.linode.upbound.io/v1alpha1, kind=key", "namespace": "", "name": "foo3", "reconcileID": "e25e3b74-91f7-4f9c-aa38-b4bcd6130544", "error": "panic: runtime error: invalid memory address or nil pointer dereference [recovered]"}
```
causing the resource to never become "Ready"
- After pointing to the upjet fork, creating a key successfully becomes "Ready" and logs don't show the `nil pointer dereference` error anymore.

[contribution process]: https://git.io/fj2m9
