### PR TITLE
Add ipv4 to the late-initialize ignored fields

### DIFF
--- a/apis/instance/v1alpha1/zz_instance_terraformed.go
+++ b/apis/instance/v1alpha1/zz_instance_terraformed.go
@@ -120,6 +120,7 @@ func (tr *Instance) LateInitialize(attrs []byte) (bool, error) {
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
 	opts = append(opts, resource.WithNameFilter("Config"))
 	opts = append(opts, resource.WithNameFilter("Disk"))
+	opts = append(opts, resource.WithNameFilter("IPv4"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/config/instance/config.go
+++ b/config/instance/config.go
@@ -9,8 +9,9 @@ func Configure(p *config.Provider) {
 		// this resource, which would be "linode"
 		r.ShortGroup = "instance"
 		r.UseAsync = true
+
 		r.LateInitializer = config.LateInitializer{
-			IgnoredFields: []string{"disk", "config"},
+			IgnoredFields: []string{"disk", "config", "ipv4"},
 		}
 
 		r.References["stackscript_id"] = config.Reference{

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -74,8 +74,10 @@ type: Opaque
 5. Test changes locally with `make local-deploy` - create a manifest for your resource and test that it works.
 
 ### Debugging using dlv:
-1. use `make run` to run the provider locally
-2. `dlv attach <pid>` to begin a debug session
+1. `make controlplane.up` - will start a kind cluster with everything needed
+2. `make generate` to generate crd's and other generated code
+3. `k apply -f package/crds` to install CRDs
+4. use `make debug` to run the provider locally
 
 
 ### Creating and publishing xpkgs

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,7 @@ go 1.23.0
 
 toolchain go1.24.2
 
-replace (
-	github.com/crossplane/crossplane-runtime => github.com/guilhem/crossplane-runtime v1.16.1-0.20250116161626-a92ea4102aa4
-	github.com/linode/terraform-provider-linode/v2 => github.com/tchinmai7/terraform-provider-linode/v2 v2.37.1-0.20250410211733-1b24dfd5b938
-)
+replace github.com/crossplane/crossplane-runtime => github.com/guilhem/crossplane-runtime v1.16.1-0.20250116161626-a92ea4102aa4
 
 require (
 	dario.cat/mergo v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -238,6 +238,8 @@ github.com/linode/linodego v1.49.0 h1:MNd3qwvQzbXB5mCpvdCqlUIu1RPA9oC+50LyB9kK+G
 github.com/linode/linodego v1.49.0/go.mod h1:B+HAM3//4w1wOS0BwdaQBKwBxlfe6kYJ7bSC6jJ/xtc=
 github.com/linode/linodego/k8s v1.25.2 h1:PY6S0sAD3xANVvM9WY38bz9GqMTjIbytC8IJJ9Cv23o=
 github.com/linode/linodego/k8s v1.25.2/go.mod h1:DC1XCSRZRGsmaa/ggpDPSDUmOM6aK1bhSIP6+f9Cwhc=
+github.com/linode/terraform-provider-linode/v2 v2.37.0 h1:mVADbhJ9s9fGfQJFXEeVheTjg64Se0waZ78Qu8A09as=
+github.com/linode/terraform-provider-linode/v2 v2.37.0/go.mod h1:Th2/ECI4q9Ivq3OeQXR0Wui1E5JEPcZNGZRbxNb0GPE=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
@@ -319,8 +321,6 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/tchinmai7/terraform-provider-linode/v2 v2.37.1-0.20250410211733-1b24dfd5b938 h1:CbRKtIBHeYc9a6Ko1lxRLtUi/F9XCHcSZR8C1xA/xBI=
-github.com/tchinmai7/terraform-provider-linode/v2 v2.37.1-0.20250410211733-1b24dfd5b938/go.mod h1:Th2/ECI4q9Ivq3OeQXR0Wui1E5JEPcZNGZRbxNb0GPE=
 github.com/tmccombs/hcl2json v0.3.3 h1:+DLNYqpWE0CsOQiEZu+OZm5ZBImake3wtITYxQ8uLFQ=
 github.com/tmccombs/hcl2json v0.3.3/go.mod h1:Y2chtz2x9bAeRTvSibVRVgbLJhLJXKlUeIvjeVdnm4w=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
The linode API is now surfacing ALL ips on the linode, including ones that are added out of band. The instance's `forProvider` configuration shouldn't save the IPs, they are automatically assigned by linode. Adding it to the `ignoredFields`  of late-initalizer fixes this problem. Also go back to upstream terraform library

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

1.`make local-deploy`
2. Create a linode secret & provider config
```
apiVersion: v1
data:
  credentials: YourCREDSHERE
kind: Secret
metadata:
  name: linode-api-token
  namespace: default
type: Opaque
---
apiVersion: linode.upbound.io/v1beta1
kind: ProviderConfig
metadata:
  name: default
spec:
  credentials:
    source: Secret
    secretRef:
      name: linode-api-token
      namespace: default
      key: credentials
  config:
    obj_bucket_force_delete: true
    obj_use_temp_keys: true
```
3. create a instance and IP
```
apiVersion: instance.linode.upbound.io/v1alpha1
kind: Instance
metadata:
  name: "test-instance-take4"
  labels:
    foo.linode.com/type: ip-holder
spec:
  forProvider:
    region: "us-sea"
    backupsEnabled: false
    booted: false
    privateIp: false
    type: g6-nanode-1
    watchdogEnabled: false
---
apiVersion: instance.linode.upbound.io/v1alpha1
kind: IP
metadata:
  name: "test-ip-take4"
spec:
  forProvider:
    applyImmediately: true
    public: true
    linodeIdSelector:
      matchLabels:
        foo.linode.com/type: ip-holder
``` 
4. Wait for it to be synced. Edit an annotation on the instance after ~60 seconds to force a reconcile.
5. Verify that the instance stays synced, `atProvider.ipv4` shows 2 ips and `forProvider` doesn't have any
[contribution process]: https://git.io/fj2m9
